### PR TITLE
Makefile: Pass -ffile-prefix-map in CFLAGS to avoid embedding the

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Copyright (c) 2020-2022 Brett Sheffield <bacs@librecast.net>
 
 SHELL := bash
-CFLAGS := -Wall -Wextra -Wpedantic -g
+CFLAGS := -Wall -Wextra -Wpedantic -g -ffile-prefix-map=$(CURDIR)=.
 CFLAGS-CLANG := -Wno-gnu-zero-variadic-macro-arguments
 export CFLAGS
 INSTALLDIR := /usr/local/bin


### PR DESCRIPTION
build path.