### PR TITLE
src/Makefile: allow overriding setcap with SETCAP_PROGRAM.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,7 @@ exec_prefix := $(prefix)
 bindir := $(exec_prefix)/bin
 LDFLAGS += -lm -pthread -llibrecast
 OBJS = $(PROGRAM).o arg.o file.o globals.o help.o job.o log.o mdex.o misc.o mld.o mtree.o net.o opt.o vec.o
+SETCAP_PROGRAM ?= setcap
 
 all:		$(PROGRAM)
 
@@ -23,7 +24,7 @@ misc.o:		misc.h
 install:        all
 		$(INSTALL) -d $(DESTDIR)$(bindir)
 		$(INSTALL_PROGRAM) $(PROGRAM) $(DESTDIR)$(bindir)/$(PROGRAM)
-		setcap cap_net_raw=eip $(DESTDIR)$(bindir)/$(PROGRAM)
+		$(SETCAP_PROGRAM) cap_net_raw=eip $(DESTDIR)$(bindir)/$(PROGRAM)
 
 .PHONY: clean realclean setcap
 


### PR DESCRIPTION
This allows building when setcap is not available, such as building a
package that instead runs a setcap when installing the package.