### PR TITLE
src/log.*: Remove license headers which conflict with SPDX

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -1,24 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
- *
- * log.c
- *
- * this file is part of LIBRESTACK
- *
  * Copyright (c) 2012-2022 Brett Sheffield <bacs@librecast.net>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program (see the file COPYING in the distribution).
- * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <assert.h>

--- a/src/log.h
+++ b/src/log.h
@@ -1,24 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
- *
- * log.h
- *
- * this file is part of LIBRESTACK
- *
  * Copyright (c) 2012-2022 Brett Sheffield <bacs@librecast.net>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program (see the file COPYING in the distribution).
- * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __LSD_LOG


### PR DESCRIPTION
identifiers.

My understanding is the copyright holder wishes to explicitly license
under the GPL-2 or the GPL-3, not necessarily later versions.